### PR TITLE
Resolution to issue 145 and added a ConnectWithContext to the Client

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ mikehall76 <mikehall492@gmail.com>
 mtryfoss <morten@tryfoss.no>
 realrainer <18657361+realrainer@users.noreply.github.com>
 seanchann <seanchann.zhou@gmail.com>
+dcropp <dcropp@amtelco.com>

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -21,8 +21,8 @@ import (
 // Logger defaults to a discard handler (null output).
 // If you wish to enable logging, you can set your own
 // handler like so:
-// 		ari.Logger.SetHandler(log15.StderrHandler)
 //
+//	ari.Logger.SetHandler(log15.StderrHandler)
 var Logger = log15.New()
 
 func init() {
@@ -315,6 +315,9 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
+			if wg != nil {
+				wg.Done()
+			}
 			return
 		}
 


### PR DESCRIPTION
Issue 145.  If the Client was performing a Connect/listen but did not actually connect, cancelling the Connect's Background Context never called the waitgroup Done before leaving the function.  This resulted in the Connect's wg.Wait being permanently stuck.

Also added a ConnectWithContext to the Client.  If the Connect has not succeeded (wrong IP, username/password, Asterisk system is down, ...), the caller's Context may be cancelled.  If the calling code needs to allow the calling code to cancel the ConnectWithContext, they can pass their Context and the code will detect this.  Modified the existing Connect code to pass the context.Background to the ConnectWithContext to eliminate what is essentially redundant code.