### PR TITLE
Issue145

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ mikehall76 <mikehall492@gmail.com>
 mtryfoss <morten@tryfoss.no>
 realrainer <18657361+realrainer@users.noreply.github.com>
 seanchann <seanchann.zhou@gmail.com>
+dcropp <dcropp@amtelco.com>

--- a/client/native/client.go
+++ b/client/native/client.go
@@ -21,8 +21,8 @@ import (
 // Logger defaults to a discard handler (null output).
 // If you wish to enable logging, you can set your own
 // handler like so:
-// 		ari.Logger.SetHandler(log15.StderrHandler)
 //
+//	ari.Logger.SetHandler(log15.StderrHandler)
 var Logger = log15.New()
 
 func init() {
@@ -315,6 +315,9 @@ func (c *Client) listen(ctx context.Context, wg *sync.WaitGroup) {
 	for {
 		// Exit if our context has been closed
 		if ctx.Err() != nil {
+			if wg != nil {
+				wg.Done()
+			}
 			return
 		}
 


### PR DESCRIPTION
The change I submitted two days ago had a bug.  
The listen ctx.Err check with exit should use the sync once Do wg.Done.

When the DialConfig never succeeds and the Context Done is detected, this will be the first time the sync once is called so it correctly done's the wg.  This allows the Connect to detect it's wait is over and exit.

When the DialConfig succeeds and the Asterisk info is retrieved successfully, it sets the client connected flag. Then it will perform the sync once wg.Done.  This allows the Connect to detect it's done and return to the caller.  After this, when the context is closed, the listen function will detect it's done and exit. In this case, the ctx.Err check at the start of the for loop must not call the wg.Done (it was called after the successful connection).

This change would an addition to the the one I previously committed.  (Changed from wg.Done() to signalUp.Do(wg.Done))